### PR TITLE
optimize SEO with dual descriptions and introduction page

### DIFF
--- a/account.mdx
+++ b/account.mdx
@@ -1,7 +1,12 @@
 ---
-title: Account
+title: Account Settings - Manage AI Credits, Subscription & Profile - Summate
 icon: user-gear
-description: Manage your account settings, credits, and subscription
+description: Account settings and management
+metatags:
+  description: Manage your Summate account settings including timezone configuration, AI credit usage tracking, subscription billing, and inbox setup. Update profile details and monitor credit balance.
+  "og:title": Summate Account Settings - Credits, Billing & Profile
+  "og:description": Configure your account settings, track AI credit usage, manage subscription billing, and update your profile and timezone settings.
+keywords: ["account settings", "ai credits", "subscription", "billing", "profile", "timezone"]
 ---
 
 Access your account settings to manage your profile, monitor AI credits, and control your subscription.

--- a/account.mdx
+++ b/account.mdx
@@ -1,8 +1,9 @@
 ---
-title: Account Settings - Manage AI Credits, Subscription & Profile - Summate
+title: Account
 icon: user-gear
 description: Account settings and management
 metatags:
+  title: Account Settings - Manage AI Credits, Subscription & Profile - Summate
   description: Manage your Summate account settings including timezone configuration, AI credit usage tracking, subscription billing, and inbox setup. Update profile details and monitor credit balance.
   "og:title": Summate Account Settings - Credits, Billing & Profile
   "og:description": Configure your account settings, track AI credit usage, manage subscription billing, and update your profile and timezone settings.

--- a/account.mdx
+++ b/account.mdx
@@ -1,12 +1,9 @@
 ---
 title: Account
 icon: user-gear
-description: Account settings and management
-metatags:
-  title: Account Settings - Manage AI Credits, Subscription & Profile - Summate
-  description: Manage your Summate account settings including timezone configuration, AI credit usage tracking, subscription billing, and inbox setup. Update profile details and monitor credit balance.
-  "og:title": Summate Account Settings - Credits, Billing & Profile
-  "og:description": Configure your account settings, track AI credit usage, manage subscription billing, and update your profile and timezone settings.
+description: Manage your Summate account settings including timezone configuration, AI credit usage tracking, subscription billing, and inbox setup. Update profile details and monitor credit balance.
+"og:title": Summate Account Settings - Credits, Billing & Profile
+"og:description": Configure your account settings, track AI credit usage, manage subscription billing, and update your profile and timezone settings.
 keywords: ["account settings", "ai credits", "subscription", "billing", "profile", "timezone"]
 ---
 

--- a/account.mdx
+++ b/account.mdx
@@ -1,9 +1,9 @@
 ---
 title: Account
 icon: user-gear
-description: Manage your Summate account settings including timezone configuration, AI credit usage tracking, subscription billing, and inbox setup. Update profile details and monitor credit balance.
-"og:title": Summate Account Settings - Credits, Billing & Profile
-"og:description": Configure your account settings, track AI credit usage, manage subscription billing, and update your profile and timezone settings.
+description: Account settings and management
+"og:title": Account Settings - Manage AI Credits, Billing & Profile | Summate
+"og:description": Manage your Summate account settings including timezone configuration, AI credit usage tracking, subscription billing, and inbox setup. Update profile details and monitor credit balance.
 keywords: ["account settings", "ai credits", "subscription", "billing", "profile", "timezone"]
 ---
 

--- a/concepts/ai.mdx
+++ b/concepts/ai.mdx
@@ -1,7 +1,12 @@
 ---
-title: AI Personalization
+title: AI Personalization - Custom Instructions for Newsletter Summaries - Summate
 icon: sparkles
-description: Understanding how Summate uses AI to summarize and personalize your content
+description: AI-powered content summarization
+metatags:
+  description: Customize how AI summarizes your content with block, digest, or account-level instructions. Learn to personalize TLDR summaries and key takeaways for better insights from newsletters and videos.
+  "og:title": Summate AI Personalization - Custom Summary Instructions
+  "og:description": Add custom instructions to personalize AI summaries. Control how newsletters, YouTube videos, and blogs are summarized at multiple levels.
+keywords: ["ai personalization", "custom instructions", "tldr", "summaries", "ai customization"]
 ---
 
 Summate uses AI to transform hours of reading into digestible summaries tailored to your interests. Our AI continuously monitors your sources and creates personalized summaries based on your custom instructions.

--- a/concepts/ai.mdx
+++ b/concepts/ai.mdx
@@ -1,8 +1,9 @@
 ---
-title: AI Personalization - Custom Instructions for Newsletter Summaries - Summate
+title: AI Personalization
 icon: sparkles
 description: AI-powered content summarization
 metatags:
+  title: AI Personalization - Custom Instructions for Newsletter Summaries - Summate
   description: Customize how AI summarizes your content with block, digest, or account-level instructions. Learn to personalize TLDR summaries and key takeaways for better insights from newsletters and videos.
   "og:title": Summate AI Personalization - Custom Summary Instructions
   "og:description": Add custom instructions to personalize AI summaries. Control how newsletters, YouTube videos, and blogs are summarized at multiple levels.

--- a/concepts/ai.mdx
+++ b/concepts/ai.mdx
@@ -1,12 +1,9 @@
 ---
 title: AI Personalization
 icon: sparkles
-description: AI-powered content summarization
-metatags:
-  title: AI Personalization - Custom Instructions for Newsletter Summaries - Summate
-  description: Customize how AI summarizes your content with block, digest, or account-level instructions. Learn to personalize TLDR summaries and key takeaways for better insights from newsletters and videos.
-  "og:title": Summate AI Personalization - Custom Summary Instructions
-  "og:description": Add custom instructions to personalize AI summaries. Control how newsletters, YouTube videos, and blogs are summarized at multiple levels.
+description: Customize how AI summarizes your content with block, digest, or account-level instructions. Learn to personalize TLDR summaries and key takeaways for better insights from newsletters and videos.
+"og:title": Summate AI Personalization - Custom Summary Instructions
+"og:description": Add custom instructions to personalize AI summaries. Control how newsletters, YouTube videos, and blogs are summarized at multiple levels.
 keywords: ["ai personalization", "custom instructions", "tldr", "summaries", "ai customization"]
 ---
 

--- a/concepts/ai.mdx
+++ b/concepts/ai.mdx
@@ -1,9 +1,9 @@
 ---
 title: AI Personalization
 icon: sparkles
-description: Customize how AI summarizes your content with block, digest, or account-level instructions. Learn to personalize TLDR summaries and key takeaways for better insights from newsletters and videos.
-"og:title": Summate AI Personalization - Custom Summary Instructions
-"og:description": Add custom instructions to personalize AI summaries. Control how newsletters, YouTube videos, and blogs are summarized at multiple levels.
+description: AI-powered content summarization
+"og:title": AI Personalization - Custom Summary Instructions | Summate
+"og:description": Customize how AI summarizes your content with block, digest, or account-level instructions. Learn to personalize TLDR summaries and key takeaways for better insights from newsletters and videos.
 keywords: ["ai personalization", "custom instructions", "tldr", "summaries", "ai customization"]
 ---
 

--- a/concepts/blocks.mdx
+++ b/concepts/blocks.mdx
@@ -1,7 +1,12 @@
 ---
-title: Blocks
+title: Content Blocks - Organize Email, YouTube & RSS in Digests - Summate
 icon: cube
-description: Understanding content blocks - the building units of your digests
+description: Building units of your digests
+metatags:
+  description: Blocks are modular content sections in your digest. Learn how to add email newsletters, YouTube channels, and RSS feeds to create customized AI-powered summaries for each source type.
+  "og:title": Summate Blocks - Organize Newsletter, YouTube & Blog Content
+  "og:description": Add email, YouTube, and RSS blocks to your digest. Customize AI summaries for each content type with custom instructions.
+keywords: ["blocks", "email block", "youtube block", "rss block", "content organization", "modular"]
 ---
 
 Blocks are the building units of your digests. Each block pulls content from specific sources and generates AI summaries based on your custom instructions.

--- a/concepts/blocks.mdx
+++ b/concepts/blocks.mdx
@@ -1,8 +1,9 @@
 ---
-title: Content Blocks - Organize Email, YouTube & RSS in Digests - Summate
+title: Blocks
 icon: cube
 description: Building units of your digests
 metatags:
+  title: Content Blocks - Organize Email, YouTube & RSS in Digests - Summate
   description: Blocks are modular content sections in your digest. Learn how to add email newsletters, YouTube channels, and RSS feeds to create customized AI-powered summaries for each source type.
   "og:title": Summate Blocks - Organize Newsletter, YouTube & Blog Content
   "og:description": Add email, YouTube, and RSS blocks to your digest. Customize AI summaries for each content type with custom instructions.

--- a/concepts/blocks.mdx
+++ b/concepts/blocks.mdx
@@ -1,9 +1,9 @@
 ---
 title: Blocks
 icon: cube
-description: Blocks are modular content sections in your digest. Learn how to add email newsletters, YouTube channels, and RSS feeds to create customized AI-powered summaries for each source type.
-"og:title": Summate Blocks - Organize Newsletter, YouTube & Blog Content
-"og:description": Add email, YouTube, and RSS blocks to your digest. Customize AI summaries for each content type with custom instructions.
+description: Building units of your digests
+"og:title": Content Blocks - Organize Newsletters, YouTube & RSS Feeds | Summate
+"og:description": Blocks are modular content sections in your digest. Learn how to add email newsletters, YouTube channels, and RSS feeds to create customized AI-powered summaries for each source type.
 keywords: ["blocks", "email block", "youtube block", "rss block", "content organization", "modular"]
 ---
 

--- a/concepts/blocks.mdx
+++ b/concepts/blocks.mdx
@@ -1,12 +1,9 @@
 ---
 title: Blocks
 icon: cube
-description: Building units of your digests
-metatags:
-  title: Content Blocks - Organize Email, YouTube & RSS in Digests - Summate
-  description: Blocks are modular content sections in your digest. Learn how to add email newsletters, YouTube channels, and RSS feeds to create customized AI-powered summaries for each source type.
-  "og:title": Summate Blocks - Organize Newsletter, YouTube & Blog Content
-  "og:description": Add email, YouTube, and RSS blocks to your digest. Customize AI summaries for each content type with custom instructions.
+description: Blocks are modular content sections in your digest. Learn how to add email newsletters, YouTube channels, and RSS feeds to create customized AI-powered summaries for each source type.
+"og:title": Summate Blocks - Organize Newsletter, YouTube & Blog Content
+"og:description": Add email, YouTube, and RSS blocks to your digest. Customize AI summaries for each content type with custom instructions.
 keywords: ["blocks", "email block", "youtube block", "rss block", "content organization", "modular"]
 ---
 

--- a/concepts/digests.mdx
+++ b/concepts/digests.mdx
@@ -1,12 +1,9 @@
 ---
 title: Digests
 icon: newspaper
-description: Scheduled AI summaries from your content sources
-metatags:
-  title: What are Digests? | AI-Powered Newsletter Summaries - Summate
-  description: Digests are scheduled AI summaries of your newsletters, YouTube videos, and blogs. Learn how to create, customize, and automate content digests delivered on your schedule.
-  "og:title": Summate Digests - AI Newsletter Summaries on Your Schedule
-  "og:description": Create personalized content digests that automatically summarize newsletters, YouTube, and blogs. Schedule daily, weekly, or monthly delivery.
+description: Digests are scheduled AI summaries of your newsletters, YouTube videos, and blogs. Learn how to create, customize, and automate content digests delivered on your schedule.
+"og:title": Summate Digests - AI Newsletter Summaries on Your Schedule
+"og:description": Create personalized content digests that automatically summarize newsletters, YouTube, and blogs. Schedule daily, weekly, or monthly delivery.
 keywords: ["digests", "newsletter summary", "automate", "scheduled", "content aggregation"]
 ---
 

--- a/concepts/digests.mdx
+++ b/concepts/digests.mdx
@@ -1,8 +1,9 @@
 ---
-title: What are Digests? | AI-Powered Newsletter Summaries - Summate
+title: Digests
 icon: newspaper
 description: Scheduled AI summaries from your content sources
 metatags:
+  title: What are Digests? | AI-Powered Newsletter Summaries - Summate
   description: Digests are scheduled AI summaries of your newsletters, YouTube videos, and blogs. Learn how to create, customize, and automate content digests delivered on your schedule.
   "og:title": Summate Digests - AI Newsletter Summaries on Your Schedule
   "og:description": Create personalized content digests that automatically summarize newsletters, YouTube, and blogs. Schedule daily, weekly, or monthly delivery.

--- a/concepts/digests.mdx
+++ b/concepts/digests.mdx
@@ -1,7 +1,12 @@
 ---
-title: Digests
+title: What are Digests? | AI-Powered Newsletter Summaries - Summate
 icon: newspaper
-description: Understanding how digests work and how to customize them
+description: Scheduled AI summaries from your content sources
+metatags:
+  description: Digests are scheduled AI summaries of your newsletters, YouTube videos, and blogs. Learn how to create, customize, and automate content digests delivered on your schedule.
+  "og:title": Summate Digests - AI Newsletter Summaries on Your Schedule
+  "og:description": Create personalized content digests that automatically summarize newsletters, YouTube, and blogs. Schedule daily, weekly, or monthly delivery.
+keywords: ["digests", "newsletter summary", "automate", "scheduled", "content aggregation"]
 ---
 
 A digest is your personalized content report based on what happened during a specific timeframe. Think of it as a custom newspaper that automatically assembles summaries from all your sources and delivers them on your schedule.

--- a/concepts/digests.mdx
+++ b/concepts/digests.mdx
@@ -1,9 +1,9 @@
 ---
 title: Digests
 icon: newspaper
-description: Digests are scheduled AI summaries of your newsletters, YouTube videos, and blogs. Learn how to create, customize, and automate content digests delivered on your schedule.
-"og:title": Summate Digests - AI Newsletter Summaries on Your Schedule
-"og:description": Create personalized content digests that automatically summarize newsletters, YouTube, and blogs. Schedule daily, weekly, or monthly delivery.
+description: Scheduled AI summaries from your content sources
+"og:title": Personal AI Digests - Scheduled Summaries of Your Content | Summate
+"og:description": Digests are scheduled AI summaries of your newsletters, YouTube videos, and blogs. Learn how to create, customize, and automate content digests delivered on your schedule.
 keywords: ["digests", "newsletter summary", "automate", "scheduled", "content aggregation"]
 ---
 

--- a/concepts/inbox.mdx
+++ b/concepts/inbox.mdx
@@ -1,8 +1,9 @@
 ---
-title: Summate Inbox - Your Private Email Address for Newsletters
+title: Inbox
 icon: inbox
 description: Your personal inbox for newsletters
 metatags:
+  title: Summate Inbox - Your Private Email Address for Newsletters
   description: Get a unique inbox address to collect newsletters privately. Learn how to set up email forwarding, manage newsletter senders, and keep your personal inbox clean with Summate.
   "og:title": Summate Inbox - Private Email for Newsletter Management
   "og:description": Unique email address for collecting newsletters. Set up forwarding, manage senders, and block spam with one click.

--- a/concepts/inbox.mdx
+++ b/concepts/inbox.mdx
@@ -1,7 +1,12 @@
 ---
-title: Inbox
+title: Summate Inbox - Your Private Email Address for Newsletters
 icon: inbox
-description: Your personal inbox for collecting and managing newsletters
+description: Your personal inbox for newsletters
+metatags:
+  description: Get a unique inbox address to collect newsletters privately. Learn how to set up email forwarding, manage newsletter senders, and keep your personal inbox clean with Summate.
+  "og:title": Summate Inbox - Private Email for Newsletter Management
+  "og:description": Unique email address for collecting newsletters. Set up forwarding, manage senders, and block spam with one click.
+keywords: ["inbox", "email forwarding", "newsletter management", "private email", "sender management"]
 ---
 
 Your Summate Inbox is a unique email address that collects newsletters for your digests while keeping your personal emails private.

--- a/concepts/inbox.mdx
+++ b/concepts/inbox.mdx
@@ -1,12 +1,9 @@
 ---
 title: Inbox
 icon: inbox
-description: Your personal inbox for newsletters
-metatags:
-  title: Summate Inbox - Your Private Email Address for Newsletters
-  description: Get a unique inbox address to collect newsletters privately. Learn how to set up email forwarding, manage newsletter senders, and keep your personal inbox clean with Summate.
-  "og:title": Summate Inbox - Private Email for Newsletter Management
-  "og:description": Unique email address for collecting newsletters. Set up forwarding, manage senders, and block spam with one click.
+description: Get a unique inbox address to collect newsletters privately. Learn how to set up email forwarding, manage newsletter senders, and keep your personal inbox clean with Summate.
+"og:title": Summate Inbox - Private Email for Newsletter Management
+"og:description": Unique email address for collecting newsletters. Set up forwarding, manage senders, and block spam with one click.
 keywords: ["inbox", "email forwarding", "newsletter management", "private email", "sender management"]
 ---
 

--- a/concepts/inbox.mdx
+++ b/concepts/inbox.mdx
@@ -1,9 +1,9 @@
 ---
 title: Inbox
 icon: inbox
-description: Get a unique inbox address to collect newsletters privately. Learn how to set up email forwarding, manage newsletter senders, and keep your personal inbox clean with Summate.
-"og:title": Summate Inbox - Private Email for Newsletter Management
-"og:description": Unique email address for collecting newsletters. Set up forwarding, manage senders, and block spam with one click.
+description: Your personal inbox for newsletters
+"og:title": Summate Inbox - Private Email Address for Newsletter Management
+"og:description": Get a unique inbox address to collect newsletters privately. Learn how to set up email forwarding, manage newsletter senders, and keep your personal inbox clean with Summate.
 keywords: ["inbox", "email forwarding", "newsletter management", "private email", "sender management"]
 ---
 

--- a/concepts/sources.mdx
+++ b/concepts/sources.mdx
@@ -1,7 +1,12 @@
 ---
-title: Sources
+title: Managing Content Sources - Newsletters, YouTube & RSS Feeds - Summate
 icon: rss
-description: Understanding and managing your content sources
+description: Individual content providers in your digests
+metatags:
+  description: Sources are individual content providers in your digests. Learn how to add, organize, and manage newsletter senders, YouTube channels, and blog RSS feeds in Summate.
+  "og:title": Summate Sources - Manage Newsletters, YouTube & Blogs
+  "og:description": Add and manage email newsletters, YouTube channels, and RSS blog feeds as sources for your AI-powered digests.
+keywords: ["sources", "content providers", "newsletters", "youtube channels", "rss feeds", "manage sources"]
 ---
 
 Sources are the individual content providers within your [blocks](/concepts/blocks) - each YouTube channel, RSS blog, or email sender that you add to create your digests.

--- a/concepts/sources.mdx
+++ b/concepts/sources.mdx
@@ -1,12 +1,9 @@
 ---
 title: Sources
 icon: rss
-description: Individual content providers in your digests
-metatags:
-  title: Managing Content Sources - Newsletters, YouTube & RSS Feeds - Summate
-  description: Sources are individual content providers in your digests. Learn how to add, organize, and manage newsletter senders, YouTube channels, and blog RSS feeds in Summate.
-  "og:title": Summate Sources - Manage Newsletters, YouTube & Blogs
-  "og:description": Add and manage email newsletters, YouTube channels, and RSS blog feeds as sources for your AI-powered digests.
+description: Sources are individual content providers in your digests. Learn how to add, organize, and manage newsletter senders, YouTube channels, and blog RSS feeds in Summate.
+"og:title": Summate Sources - Manage Newsletters, YouTube & Blogs
+"og:description": Add and manage email newsletters, YouTube channels, and RSS blog feeds as sources for your AI-powered digests.
 keywords: ["sources", "content providers", "newsletters", "youtube channels", "rss feeds", "manage sources"]
 ---
 

--- a/concepts/sources.mdx
+++ b/concepts/sources.mdx
@@ -1,8 +1,9 @@
 ---
-title: Managing Content Sources - Newsletters, YouTube & RSS Feeds - Summate
+title: Sources
 icon: rss
 description: Individual content providers in your digests
 metatags:
+  title: Managing Content Sources - Newsletters, YouTube & RSS Feeds - Summate
   description: Sources are individual content providers in your digests. Learn how to add, organize, and manage newsletter senders, YouTube channels, and blog RSS feeds in Summate.
   "og:title": Summate Sources - Manage Newsletters, YouTube & Blogs
   "og:description": Add and manage email newsletters, YouTube channels, and RSS blog feeds as sources for your AI-powered digests.

--- a/concepts/sources.mdx
+++ b/concepts/sources.mdx
@@ -1,9 +1,9 @@
 ---
 title: Sources
 icon: rss
-description: Sources are individual content providers in your digests. Learn how to add, organize, and manage newsletter senders, YouTube channels, and blog RSS feeds in Summate.
-"og:title": Summate Sources - Manage Newsletters, YouTube & Blogs
-"og:description": Add and manage email newsletters, YouTube channels, and RSS blog feeds as sources for your AI-powered digests.
+description: Individual content providers in your digests
+"og:title": Content Sources - Manage Newsletters, YouTube & RSS Feeds | Summate
+"og:description": Sources are individual content providers in your digests. Learn how to add, organize, and manage newsletter senders, YouTube channels, and blog RSS feeds in Summate.
 keywords: ["sources", "content providers", "newsletters", "youtube channels", "rss feeds", "manage sources"]
 ---
 

--- a/getting-started/faq.mdx
+++ b/getting-started/faq.mdx
@@ -1,9 +1,9 @@
 ---
 title: Frequently Asked Questions
 icon: circle-question
-description: Get answers to common questions about Summate's AI newsletter digests including pricing, credit usage, email forwarding setup, troubleshooting delivery issues, and feature details.
-"og:title": Summate FAQ - Frequently Asked Questions
-"og:description": Everything you need to know about AI newsletter digests, pricing, features, and troubleshooting. Answers to common Summate questions.
+description: Common questions about Summate
+"og:title": FAQ - Frequently Asked Questions | Summate
+"og:description": Get answers to common questions about Summate's AI newsletter digests including pricing, credit usage, email forwarding setup, troubleshooting delivery issues, and feature details.
 keywords: ["faq", "help", "pricing", "credits", "troubleshooting", "features"]
 ---
 

--- a/getting-started/faq.mdx
+++ b/getting-started/faq.mdx
@@ -1,8 +1,9 @@
 ---
-title: Summate FAQ - Pricing, Features & Troubleshooting
+title: Frequently Asked Questions
 icon: circle-question
 description: Common questions about Summate
 metatags:
+  title: Summate FAQ - Pricing, Features & Troubleshooting
   description: Get answers to common questions about Summate's AI newsletter digests including pricing, credit usage, email forwarding setup, troubleshooting delivery issues, and feature details.
   "og:title": Summate FAQ - Frequently Asked Questions
   "og:description": Everything you need to know about AI newsletter digests, pricing, features, and troubleshooting. Answers to common Summate questions.

--- a/getting-started/faq.mdx
+++ b/getting-started/faq.mdx
@@ -1,7 +1,12 @@
 ---
-title: Frequently Asked Questions
+title: Summate FAQ - Pricing, Features & Troubleshooting
 icon: circle-question
 description: Common questions about Summate
+metatags:
+  description: Get answers to common questions about Summate's AI newsletter digests including pricing, credit usage, email forwarding setup, troubleshooting delivery issues, and feature details.
+  "og:title": Summate FAQ - Frequently Asked Questions
+  "og:description": Everything you need to know about AI newsletter digests, pricing, features, and troubleshooting. Answers to common Summate questions.
+keywords: ["faq", "help", "pricing", "credits", "troubleshooting", "features"]
 ---
 
 ## Getting Started

--- a/getting-started/faq.mdx
+++ b/getting-started/faq.mdx
@@ -1,12 +1,9 @@
 ---
 title: Frequently Asked Questions
 icon: circle-question
-description: Common questions about Summate
-metatags:
-  title: Summate FAQ - Pricing, Features & Troubleshooting
-  description: Get answers to common questions about Summate's AI newsletter digests including pricing, credit usage, email forwarding setup, troubleshooting delivery issues, and feature details.
-  "og:title": Summate FAQ - Frequently Asked Questions
-  "og:description": Everything you need to know about AI newsletter digests, pricing, features, and troubleshooting. Answers to common Summate questions.
+description: Get answers to common questions about Summate's AI newsletter digests including pricing, credit usage, email forwarding setup, troubleshooting delivery issues, and feature details.
+"og:title": Summate FAQ - Frequently Asked Questions
+"og:description": Everything you need to know about AI newsletter digests, pricing, features, and troubleshooting. Answers to common Summate questions.
 keywords: ["faq", "help", "pricing", "credits", "troubleshooting", "features"]
 ---
 

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -1,12 +1,9 @@
 ---
 title: Quickstart
 icon: play
-description: Get your first digest in 5 minutes
-metatags:
-  title: Quickstart - Create Your First AI Digest in 5 Minutes | Summate
-  description: Set up Summate in 5 minutes. Automatically summarize newsletters, YouTube videos, and blogs with AI-powered digests delivered on your schedule. Free 14-day trial included.
-  "og:title": Summate Quickstart - AI Newsletter Digest in 5 Minutes
-  "og:description": Create AI-powered digests from newsletters, YouTube, and blogs in under 5 minutes. Step-by-step setup guide with free trial.
+description: Set up Summate in 5 minutes. Automatically summarize newsletters, YouTube videos, and blogs with AI-powered digests delivered on your schedule. Free 14-day trial included.
+"og:title": Summate Quickstart - AI Newsletter Digest in 5 Minutes
+"og:description": Create AI-powered digests from newsletters, YouTube, and blogs in under 5 minutes. Step-by-step setup guide with free trial.
 keywords: ["setup", "getting started", "onboarding", "first digest", "tutorial"]
 ---
 

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -1,9 +1,9 @@
 ---
 title: Quickstart
 icon: play
-description: Set up Summate in 5 minutes. Automatically summarize newsletters, YouTube videos, and blogs with AI-powered digests delivered on your schedule. Free 14-day trial included.
-"og:title": Summate Quickstart - AI Newsletter Digest in 5 Minutes
-"og:description": Create AI-powered digests from newsletters, YouTube, and blogs in under 5 minutes. Step-by-step setup guide with free trial.
+description: Get your first digest in 5 minutes
+"og:title": Quickstart - Create Your Personal AI Digest in 5 Minutes | Summate
+"og:description": Set up Summate in 5 minutes. Automatically summarize newsletters, YouTube videos, and blogs with AI-powered digests delivered on your schedule. Free 14-day trial included.
 keywords: ["setup", "getting started", "onboarding", "first digest", "tutorial"]
 ---
 

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -1,7 +1,12 @@
 ---
-title: Quickstart
+title: Quickstart - Create Your First AI Digest in 5 Minutes | Summate
 icon: play
 description: Get your first digest in 5 minutes
+metatags:
+  description: Set up Summate in 5 minutes. Automatically summarize newsletters, YouTube videos, and blogs with AI-powered digests delivered on your schedule. Free 14-day trial included.
+  "og:title": Summate Quickstart - AI Newsletter Digest in 5 Minutes
+  "og:description": Create AI-powered digests from newsletters, YouTube, and blogs in under 5 minutes. Step-by-step setup guide with free trial.
+keywords: ["setup", "getting started", "onboarding", "first digest", "tutorial"]
 ---
 
 Set up your first Summate digest in just 5 minutes and start receiving AI-powered summaries of your newsletters, YouTube videos, and blogs.

--- a/getting-started/quickstart.mdx
+++ b/getting-started/quickstart.mdx
@@ -1,8 +1,9 @@
 ---
-title: Quickstart - Create Your First AI Digest in 5 Minutes | Summate
+title: Quickstart
 icon: play
 description: Get your first digest in 5 minutes
 metatags:
+  title: Quickstart - Create Your First AI Digest in 5 Minutes | Summate
   description: Set up Summate in 5 minutes. Automatically summarize newsletters, YouTube videos, and blogs with AI-powered digests delivered on your schedule. Free 14-day trial included.
   "og:title": Summate Quickstart - AI Newsletter Digest in 5 Minutes
   "og:description": Create AI-powered digests from newsletters, YouTube, and blogs in under 5 minutes. Step-by-step setup guide with free trial.

--- a/guides/auto-forwarding.mdx
+++ b/guides/auto-forwarding.mdx
@@ -1,9 +1,9 @@
 ---
 title: Email Auto-Forwarding
-description: Set up automatic newsletter forwarding in 5 minutes. Step-by-step guides for Gmail, Outlook, iCloud, Yahoo, ProtonMail, Fastmail, and HEY with filter recommendations for selective forwarding.
+description: Set up auto-forwarding in 5 minutes
 icon: "inbox-out"
-"og:title": Email Auto-Forwarding to Summate - Complete Setup Guide
-"og:description": Forward newsletters from Gmail, Outlook, iCloud and more. Easy 5-minute setup with step-by-step screenshots and filter examples.
+"og:title": Email Auto-Forwarding Setup - Gmail, Outlook, iCloud & More | Summate
+"og:description": Set up automatic newsletter forwarding in 5 minutes. Step-by-step guides for Gmail, Outlook, iCloud, Yahoo, ProtonMail, Fastmail, and HEY with filter recommendations for selective forwarding.
 keywords: ["email forwarding", "gmail forwarding", "outlook forwarding", "newsletter forwarding", "filters", "auto-forward"]
 ---
 

--- a/guides/auto-forwarding.mdx
+++ b/guides/auto-forwarding.mdx
@@ -1,12 +1,9 @@
 ---
 title: Email Auto-Forwarding
-description: Set up auto-forwarding in 5 minutes
+description: Set up automatic newsletter forwarding in 5 minutes. Step-by-step guides for Gmail, Outlook, iCloud, Yahoo, ProtonMail, Fastmail, and HEY with filter recommendations for selective forwarding.
 icon: "inbox-out"
-metatags:
-  title: Email Auto-Forwarding Setup - Gmail, Outlook, iCloud & More - Summate
-  description: Set up automatic newsletter forwarding in 5 minutes. Step-by-step guides for Gmail, Outlook, iCloud, Yahoo, ProtonMail, Fastmail, and HEY with filter recommendations for selective forwarding.
-  "og:title": Email Auto-Forwarding to Summate - Complete Setup Guide
-  "og:description": Forward newsletters from Gmail, Outlook, iCloud and more. Easy 5-minute setup with step-by-step screenshots and filter examples.
+"og:title": Email Auto-Forwarding to Summate - Complete Setup Guide
+"og:description": Forward newsletters from Gmail, Outlook, iCloud and more. Easy 5-minute setup with step-by-step screenshots and filter examples.
 keywords: ["email forwarding", "gmail forwarding", "outlook forwarding", "newsletter forwarding", "filters", "auto-forward"]
 ---
 

--- a/guides/auto-forwarding.mdx
+++ b/guides/auto-forwarding.mdx
@@ -1,7 +1,12 @@
 ---
-title: "Email Auto-Forwarding"
-description: "Learn how to setup email auto-forwarding to get newsletters to your inbox in less than 5 minutes"
+title: Email Auto-Forwarding Setup - Gmail, Outlook, iCloud & More - Summate
+description: Set up auto-forwarding in 5 minutes
 icon: "inbox-out"
+metatags:
+  description: Set up automatic newsletter forwarding in 5 minutes. Step-by-step guides for Gmail, Outlook, iCloud, Yahoo, ProtonMail, Fastmail, and HEY with filter recommendations for selective forwarding.
+  "og:title": Email Auto-Forwarding to Summate - Complete Setup Guide
+  "og:description": Forward newsletters from Gmail, Outlook, iCloud and more. Easy 5-minute setup with step-by-step screenshots and filter examples.
+keywords: ["email forwarding", "gmail forwarding", "outlook forwarding", "newsletter forwarding", "filters", "auto-forward"]
 ---
 
 ## Overview

--- a/guides/auto-forwarding.mdx
+++ b/guides/auto-forwarding.mdx
@@ -1,8 +1,9 @@
 ---
-title: Email Auto-Forwarding Setup - Gmail, Outlook, iCloud & More - Summate
+title: Email Auto-Forwarding
 description: Set up auto-forwarding in 5 minutes
 icon: "inbox-out"
 metatags:
+  title: Email Auto-Forwarding Setup - Gmail, Outlook, iCloud & More - Summate
   description: Set up automatic newsletter forwarding in 5 minutes. Step-by-step guides for Gmail, Outlook, iCloud, Yahoo, ProtonMail, Fastmail, and HEY with filter recommendations for selective forwarding.
   "og:title": Email Auto-Forwarding to Summate - Complete Setup Guide
   "og:description": Forward newsletters from Gmail, Outlook, iCloud and more. Easy 5-minute setup with step-by-step screenshots and filter examples.

--- a/guides/substack-import.mdx
+++ b/guides/substack-import.mdx
@@ -1,7 +1,12 @@
 ---
-title: "Substack Import"
-description: "Import all your Substack subscriptions in one click"
+title: Import Substack Subscriptions - Connect & Sync in One Click - Summate
+description: One-click Substack import
 icon: "S"
+metatags:
+  description: Import all your Substack newsletter subscriptions automatically by connecting your Substack account. Learn how to sync subscriptions and add them as RSS sources to your Summate digests.
+  "og:title": Substack Import - Sync All Newsletter Subscriptions to Summate
+  "og:description": Connect your Substack account and import all newsletter subscriptions in one click. Add Substack blogs as RSS sources to your digests.
+keywords: ["substack import", "substack subscriptions", "connect substack", "import newsletters", "rss sync"]
 ---
 
 Instead of adding Substack newsletters one by one, you can connect your Substack account and import all your subscriptions at once.

--- a/guides/substack-import.mdx
+++ b/guides/substack-import.mdx
@@ -1,12 +1,9 @@
 ---
 title: Substack Import
-description: One-click Substack import
+description: Import all your Substack newsletter subscriptions automatically by connecting your Substack account. Learn how to sync subscriptions and add them as RSS sources to your Summate digests.
 icon: "S"
-metatags:
-  title: Import Substack Subscriptions - Connect & Sync in One Click - Summate
-  description: Import all your Substack newsletter subscriptions automatically by connecting your Substack account. Learn how to sync subscriptions and add them as RSS sources to your Summate digests.
-  "og:title": Substack Import - Sync All Newsletter Subscriptions to Summate
-  "og:description": Connect your Substack account and import all newsletter subscriptions in one click. Add Substack blogs as RSS sources to your digests.
+"og:title": Substack Import - Sync All Newsletter Subscriptions to Summate
+"og:description": Connect your Substack account and import all newsletter subscriptions in one click. Add Substack blogs as RSS sources to your digests.
 keywords: ["substack import", "substack subscriptions", "connect substack", "import newsletters", "rss sync"]
 ---
 

--- a/guides/substack-import.mdx
+++ b/guides/substack-import.mdx
@@ -1,9 +1,9 @@
 ---
 title: Substack Import
-description: Import all your Substack newsletter subscriptions automatically by connecting your Substack account. Learn how to sync subscriptions and add them as RSS sources to your Summate digests.
+description: One-click Substack import
 icon: "S"
-"og:title": Substack Import - Sync All Newsletter Subscriptions to Summate
-"og:description": Connect your Substack account and import all newsletter subscriptions in one click. Add Substack blogs as RSS sources to your digests.
+"og:title": Substack Import - Sync All Newsletter Subscriptions | Summate
+"og:description": Import all your Substack newsletter subscriptions automatically by connecting your Substack account. Learn how to sync subscriptions and add them as RSS sources to your Summate digests.
 keywords: ["substack import", "substack subscriptions", "connect substack", "import newsletters", "rss sync"]
 ---
 

--- a/guides/substack-import.mdx
+++ b/guides/substack-import.mdx
@@ -1,8 +1,9 @@
 ---
-title: Import Substack Subscriptions - Connect & Sync in One Click - Summate
+title: Substack Import
 description: One-click Substack import
 icon: "S"
 metatags:
+  title: Import Substack Subscriptions - Connect & Sync in One Click - Summate
   description: Import all your Substack newsletter subscriptions automatically by connecting your Substack account. Learn how to sync subscriptions and add them as RSS sources to your Summate digests.
   "og:title": Substack Import - Sync All Newsletter Subscriptions to Summate
   "og:description": Connect your Substack account and import all newsletter subscriptions in one click. Add Substack blogs as RSS sources to your digests.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,8 +1,9 @@
 ---
-title: Summate - AI Newsletter Digest & Content Aggregator
+title: Introduction
 icon: home
 description: AI-powered content aggregation platform
 metatags:
+  title: Summate - AI Newsletter Digest & Content Aggregator
   description: Summate creates AI-powered digests from your newsletters, YouTube subscriptions, and blogs. Get personalized summaries delivered on your schedule to save time and stay informed without information overload.
   "og:title": Summate - AI Newsletter Digest & Content Aggregator
   "og:description": Stop drowning in newsletters. Get AI-powered digests that summarize your newsletters, YouTube videos, and blogs on your schedule.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Welcome to Summate
 icon: home
 description: AI-powered content aggregation platform
 "og:title": Summate - Personal AI Digest for Newsletters, YouTube & RSS Feeds

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,12 +1,9 @@
 ---
 title: Introduction
 icon: home
-description: AI-powered content aggregation platform
-metatags:
-  title: Summate - AI Newsletter Digest & Content Aggregator
-  description: Summate creates AI-powered digests from your newsletters, YouTube subscriptions, and blogs. Get personalized summaries delivered on your schedule to save time and stay informed without information overload.
-  "og:title": Summate - AI Newsletter Digest & Content Aggregator
-  "og:description": Stop drowning in newsletters. Get AI-powered digests that summarize your newsletters, YouTube videos, and blogs on your schedule.
+description: Summate creates AI-powered digests from your newsletters, YouTube subscriptions, and blogs. Get personalized summaries delivered on your schedule to save time and stay informed.
+"og:title": Summate - AI Newsletter Digest & Content Aggregator
+"og:description": Stop drowning in newsletters. Get AI-powered digests that summarize your newsletters, YouTube videos, and blogs on your schedule.
 keywords: ["newsletter aggregator", "ai digest", "content aggregator", "newsletter summarizer", "youtube summarizer"]
 ---
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
 icon: home
-description: Summate creates AI-powered digests from your newsletters, YouTube subscriptions, and blogs. Get personalized summaries delivered on your schedule to save time and stay informed.
-"og:title": Summate - AI Newsletter Digest & Content Aggregator
-"og:description": Stop drowning in newsletters. Get AI-powered digests that summarize your newsletters, YouTube videos, and blogs on your schedule.
+description: AI-powered content aggregation platform
+"og:title": Summate - Personal AI Digest for Newsletters, YouTube & RSS Feeds
+"og:description": Summate creates AI-powered digests from your newsletters, YouTube subscriptions, and blogs. Get personalized summaries delivered on your schedule to save time and stay informed without information overload.
 keywords: ["newsletter aggregator", "ai digest", "content aggregator", "newsletter summarizer", "youtube summarizer"]
 ---
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,0 +1,237 @@
+---
+title: Summate - AI Newsletter Digest & Content Aggregator
+icon: home
+description: AI-powered content aggregation platform
+metatags:
+  description: Summate creates AI-powered digests from your newsletters, YouTube subscriptions, and blogs. Get personalized summaries delivered on your schedule to save time and stay informed without information overload.
+  "og:title": Summate - AI Newsletter Digest & Content Aggregator
+  "og:description": Stop drowning in newsletters. Get AI-powered digests that summarize your newsletters, YouTube videos, and blogs on your schedule.
+keywords: ["newsletter aggregator", "ai digest", "content aggregator", "newsletter summarizer", "youtube summarizer"]
+---
+
+Summate transforms your information overload into actionable insights by creating AI-powered digests from newsletters, YouTube videos, and blogs—all delivered on your schedule.
+
+<Frame caption="Configure multiple digests with different schedules and sources">
+  <img src="/images/digests-list.png" alt="Summate digests dashboard showing multiple configured digests" />
+</Frame>
+
+## What is Summate?
+
+Instead of checking multiple inboxes, apps, and websites throughout the day, Summate automatically:
+- **Collects** content from your newsletters, YouTube subscriptions, and RSS feeds
+- **Summarizes** everything using AI based on your interests and custom instructions
+- **Delivers** personalized digests on your schedule (daily, weekly, or monthly)
+
+## How It Works
+
+<Steps>
+  <Step title="Connect Your Sources">
+    Add newsletters via email forwarding, import YouTube subscriptions, or connect RSS feeds from your favorite blogs.
+  </Step>
+
+  <Step title="Create Custom Digests">
+    Build digests by adding blocks for different content types. Organize by topic, source type, or reading time.
+  </Step>
+
+  <Step title="Customize AI Summaries">
+    Add custom instructions to tell AI what to focus on. Get TLDR summaries and clickable key takeaways.
+  </Step>
+
+  <Step title="Receive on Schedule">
+    Your digests arrive via email and web at your chosen times. Read with embedded content and keyboard shortcuts.
+  </Step>
+</Steps>
+
+## Why Summate?
+
+<CardGroup cols={2}>
+  <Card title="Save Time" icon="clock">
+    Stop spending hours reading newsletters and watching videos. Get AI-generated summaries with key takeaways.
+  </Card>
+  <Card title="Stay Organized" icon="folder">
+    All your content sources in one place. No more switching between email, YouTube, and RSS readers.
+  </Card>
+  <Card title="Personalize Everything" icon="wand-magic-sparkles">
+    Custom instructions at block, digest, or account level. AI learns what matters to you.
+  </Card>
+  <Card title="Read Anywhere" icon="mobile">
+    Digests delivered via email and web. Embedded content, keyboard shortcuts, and full history.
+  </Card>
+</CardGroup>
+
+## What You Can Aggregate
+
+<Tabs>
+  <Tab title="Email Newsletters">
+    Forward newsletters from any platform (Substack, Beehiiv, ConvertKit, etc.) to your unique Summate inbox address.
+
+    **Features:**
+    - Automatic sender management
+    - One-click spam blocking
+    - Works with all email providers
+    - Keep your personal inbox private
+
+    [Learn about the Inbox →](/concepts/inbox)
+  </Tab>
+
+  <Tab title="YouTube Videos">
+    Import your YouTube subscriptions or add channels manually to get video summaries with timestamped takeaways.
+
+    **Features:**
+    - One-click subscription import
+    - Filter out Shorts
+    - Clickable timestamp links
+    - Skip to relevant moments
+
+    [Learn about YouTube blocks →](/concepts/blocks#youtube-block)
+  </Tab>
+
+  <Tab title="RSS Feeds & Blogs">
+    Add any blog or website with an RSS feed. Auto-detect feeds or paste URLs directly.
+
+    **Features:**
+    - Automatic feed detection
+    - Substack import
+    - Content filtering
+    - Paragraph-level references
+
+    [Learn about RSS blocks →](/concepts/blocks#rss-block)
+  </Tab>
+</Tabs>
+
+## Key Features
+
+### AI-Powered Summaries
+
+Every piece of content gets summarized with:
+- **TLDR** - Quick overview of the main points
+- **Key Takeaways** - Specific insights relevant to your custom instructions
+- **Interactive References** - Click takeaways to jump to exact paragraphs or video timestamps
+
+[Learn about AI Personalization →](/concepts/ai)
+
+### Flexible Scheduling
+
+Receive digests exactly when you need them:
+- **Daily** - Morning brief, afternoon updates (min. 4 hours apart)
+- **Weekly** - Specific days and times (e.g., Mon/Wed/Fri at 9 AM)
+- **Monthly** - Choose which days of the month
+
+[Learn about Digest Scheduling →](/concepts/digests#scheduling-your-digests)
+
+### Multiple Reading Options
+
+<CardGroup cols={2}>
+  <Card title="Email" icon="envelope" href="/reading/email">
+    Receive digests in your inbox. Read in any email client with interactive links to full content.
+  </Card>
+  <Card title="Web Reader" icon="globe" href="/reading/web">
+    Access all digests online with embedded content, keyboard shortcuts, and full history.
+  </Card>
+</CardGroup>
+
+## Who Uses Summate?
+
+<AccordionGroup>
+  <Accordion title="Developers & Tech Professionals" icon="code">
+    **Use Case:** Stay updated on tech news, frameworks, and industry trends without spending hours reading.
+
+    **Example Digest:** Morning Tech Brief
+    - AI newsletters (The Batch, Import AI)
+    - Dev blogs (Kent C. Dodds, Josh Comeau)
+    - YouTube channels (Fireship, Theo)
+    - Custom instructions: "Focus on practical applications and code examples"
+  </Accordion>
+
+  <Accordion title="Investors & Business Leaders" icon="chart-line">
+    **Use Case:** Monitor market trends, startup news, and business insights efficiently.
+
+    **Example Digest:** Market Intelligence
+    - Financial newsletters (Stratechery, The Diff)
+    - VC blogs (First Round, a16z)
+    - Business YouTube (Y Combinator, All-In Podcast)
+    - Custom instructions: "Highlight market trends and predictions"
+  </Accordion>
+
+  <Accordion title="Content Creators & Marketers" icon="bullhorn">
+    **Use Case:** Research trends, competitor content, and industry best practices.
+
+    **Example Digest:** Content Inspiration
+    - Marketing newsletters (Marketing Brew, Content Marketing Institute)
+    - Creator blogs (Nathan Barry, Tim Ferriss)
+    - YouTube tutorials (Ali Abdaal, Peter McKinnon)
+    - Custom instructions: "Focus on actionable tactics and real examples"
+  </Accordion>
+
+  <Accordion title="Researchers & Academics" icon="graduation-cap">
+    **Use Case:** Track publications, papers, and developments in specific fields.
+
+    **Example Digest:** Research Roundup
+    - Academic RSS feeds
+    - Research newsletters
+    - Educational YouTube channels
+    - Custom instructions: "Summarize methodologies and key findings"
+  </Accordion>
+</AccordionGroup>
+
+## Pricing
+
+**$10/month, billed yearly** during beta
+- 2000 AI credits per month (~66 items/day)
+- Unlimited digests
+- All content sources (Email, YouTube, RSS)
+- Email and web delivery
+- 14-day free trial
+
+[View Credit Pricing →](/account#ai-credits)
+
+## Get Started in 5 Minutes
+
+<CardGroup cols={3}>
+  <Card title="Quickstart Guide" icon="play" href="/getting-started/quickstart">
+    Set up your first digest in under 5 minutes with our step-by-step guide.
+  </Card>
+  <Card title="Auto-Forwarding Setup" icon="inbox-out" href="/guides/auto-forwarding">
+    Connect your existing newsletters from Gmail, Outlook, or any email provider.
+  </Card>
+  <Card title="FAQ" icon="circle-question" href="/getting-started/faq">
+    Common questions about pricing, features, and troubleshooting.
+  </Card>
+</CardGroup>
+
+## How Summate Compares
+
+<CardGroup cols={2}>
+  <Card title="vs. Reading Everything Manually">
+    **Without Summate:** 2-3 hours/day checking newsletters, YouTube, and blogs
+
+    **With Summate:** 15-30 minutes reading AI summaries with links to dive deeper
+  </Card>
+  <Card title="vs. Traditional RSS Readers">
+    **Traditional RSS:** No AI summaries, no email integration, separate app for YouTube
+
+    **Summate:** AI summaries, unified platform, email + YouTube + RSS in one digest
+  </Card>
+</CardGroup>
+
+## Next Steps
+
+Ready to stop drowning in content?
+
+<Card title="Start Free Trial" icon="rocket" href="https://summate.io">
+  **Sign up at summate.io** - No credit card required for 14-day trial
+</Card>
+
+Or explore the docs to learn more:
+
+<CardGroup cols={3}>
+  <Card title="Understand Digests" icon="newspaper" href="/concepts/digests">
+    Learn how digests and blocks work
+  </Card>
+  <Card title="AI Personalization" icon="sparkles" href="/concepts/ai">
+    Customize summaries with instructions
+  </Card>
+  <Card title="Set Up Your Inbox" icon="inbox" href="/concepts/inbox">
+    Get your unique newsletter address
+  </Card>
+</CardGroup>

--- a/mint.json
+++ b/mint.json
@@ -50,6 +50,7 @@
       "group": "Getting Started",
       "icon": "rocket",
       "pages": [
+        "introduction",
         "getting-started/quickstart",
         "getting-started/faq"
       ]
@@ -98,6 +99,14 @@
     "posthog": {
       "apiKey": "phc_e3UaWWN5DlOsm5eOXnAC6BbGKaA1BMiS1sgqpqtxoWH",
       "apiHost": "https://us.posthog.com"
+    }
+  },
+  "seo": {
+    "indexing": "navigable",
+    "metatags": {
+      "og:site_name": "Summate Documentation",
+      "og:type": "website",
+      "twitter:card": "summary_large_image"
     }
   }
 }

--- a/reading/email.mdx
+++ b/reading/email.mdx
@@ -1,12 +1,9 @@
 ---
 title: Email
 icon: envelope
-description: Digest delivery via email
-metatags:
-  title: Email Digests - Receive AI Newsletter Summaries in Your Inbox - Summate
-  description: Get AI-generated digest summaries delivered to your email inbox on schedule. Learn how email digests work, ensure delivery, and use interactive takeaway links to jump to sources.
-  "og:title": Summate Email Digests - Newsletter Summaries in Your Inbox
-  "og:description": Receive AI-powered newsletter, YouTube, and blog summaries via email. Scheduled delivery with interactive links to full content.
+description: Get AI-generated digest summaries delivered to your email inbox on schedule. Learn how email digests work, ensure delivery, and use interactive takeaway links to jump to sources.
+"og:title": Summate Email Digests - Newsletter Summaries in Your Inbox
+"og:description": Receive AI-powered newsletter, YouTube, and blog summaries via email. Scheduled delivery with interactive links to full content.
 keywords: ["email digests", "newsletter summaries", "email delivery", "inbox", "scheduled email"]
 ---
 

--- a/reading/email.mdx
+++ b/reading/email.mdx
@@ -1,7 +1,12 @@
 ---
-title: Email
+title: Email Digests - Receive AI Newsletter Summaries in Your Inbox - Summate
 icon: envelope
-description: Reading your Summate digests via email
+description: Digest delivery via email
+metatags:
+  description: Get AI-generated digest summaries delivered to your email inbox on schedule. Learn how email digests work, ensure delivery, and use interactive takeaway links to jump to sources.
+  "og:title": Summate Email Digests - Newsletter Summaries in Your Inbox
+  "og:description": Receive AI-powered newsletter, YouTube, and blog summaries via email. Scheduled delivery with interactive links to full content.
+keywords: ["email digests", "newsletter summaries", "email delivery", "inbox", "scheduled email"]
 ---
 
 Digests are delivered directly to your inbox on schedule, formatted for easy reading in any email client.

--- a/reading/email.mdx
+++ b/reading/email.mdx
@@ -1,8 +1,9 @@
 ---
-title: Email Digests - Receive AI Newsletter Summaries in Your Inbox - Summate
+title: Email
 icon: envelope
 description: Digest delivery via email
 metatags:
+  title: Email Digests - Receive AI Newsletter Summaries in Your Inbox - Summate
   description: Get AI-generated digest summaries delivered to your email inbox on schedule. Learn how email digests work, ensure delivery, and use interactive takeaway links to jump to sources.
   "og:title": Summate Email Digests - Newsletter Summaries in Your Inbox
   "og:description": Receive AI-powered newsletter, YouTube, and blog summaries via email. Scheduled delivery with interactive links to full content.

--- a/reading/email.mdx
+++ b/reading/email.mdx
@@ -1,9 +1,9 @@
 ---
 title: Email
 icon: envelope
-description: Get AI-generated digest summaries delivered to your email inbox on schedule. Learn how email digests work, ensure delivery, and use interactive takeaway links to jump to sources.
-"og:title": Summate Email Digests - Newsletter Summaries in Your Inbox
-"og:description": Receive AI-powered newsletter, YouTube, and blog summaries via email. Scheduled delivery with interactive links to full content.
+description: Digest delivery via email
+"og:title": Email Digests - Personal AI Summaries in Your Inbox | Summate
+"og:description": Get AI-generated digest summaries delivered to your email inbox on schedule. Learn how email digests work, ensure delivery, and use interactive takeaway links to jump to sources.
 keywords: ["email digests", "newsletter summaries", "email delivery", "inbox", "scheduled email"]
 ---
 

--- a/reading/web.mdx
+++ b/reading/web.mdx
@@ -1,9 +1,9 @@
 ---
 title: Web
 icon: globe
-description: Access all your digests at summate.io/v2/issues with embedded content, keyboard shortcuts, and full history. Better than email for interactive newsletter reading with embedded videos and blogs.
-"og:title": Summate Web Reader - Interactive Digest Reading Experience
-"og:description": Read digests online with embedded content, keyboard shortcuts, and access to full history. Better experience than email for newsletters, YouTube, and blogs.
+description: Online digest reader
+"og:title": Web Reader - Read Your Personal AI Digest Online | Summate
+"og:description": Access all your digests at summate.io/v2/issues with embedded content, keyboard shortcuts, and full history. Better than email for interactive newsletter reading with embedded videos and blogs.
 keywords: ["web reader", "keyboard shortcuts", "online reading", "embedded content", "digest history"]
 ---
 

--- a/reading/web.mdx
+++ b/reading/web.mdx
@@ -1,7 +1,12 @@
 ---
-title: Web
+title: Web Reader - Read Digests Online with Keyboard Shortcuts - Summate
 icon: globe
-description: Read your digests in the Summate web interface
+description: Online digest reader
+metatags:
+  description: Access all your digests at summate.io/v2/issues with embedded content, keyboard shortcuts, and full history. Better than email for interactive newsletter reading with embedded videos and blogs.
+  "og:title": Summate Web Reader - Interactive Digest Reading Experience
+  "og:description": Read digests online with embedded content, keyboard shortcuts, and access to full history. Better experience than email for newsletters, YouTube, and blogs.
+keywords: ["web reader", "keyboard shortcuts", "online reading", "embedded content", "digest history"]
 ---
 
 Access all your digests online at [summate.io/v2/issues](https://summate.io/v2/issues) with an optimized reading experience and interactive features.

--- a/reading/web.mdx
+++ b/reading/web.mdx
@@ -1,8 +1,9 @@
 ---
-title: Web Reader - Read Digests Online with Keyboard Shortcuts - Summate
+title: Web
 icon: globe
 description: Online digest reader
 metatags:
+  title: Web Reader - Read Digests Online with Keyboard Shortcuts - Summate
   description: Access all your digests at summate.io/v2/issues with embedded content, keyboard shortcuts, and full history. Better than email for interactive newsletter reading with embedded videos and blogs.
   "og:title": Summate Web Reader - Interactive Digest Reading Experience
   "og:description": Read digests online with embedded content, keyboard shortcuts, and access to full history. Better experience than email for newsletters, YouTube, and blogs.

--- a/reading/web.mdx
+++ b/reading/web.mdx
@@ -1,12 +1,9 @@
 ---
 title: Web
 icon: globe
-description: Online digest reader
-metatags:
-  title: Web Reader - Read Digests Online with Keyboard Shortcuts - Summate
-  description: Access all your digests at summate.io/v2/issues with embedded content, keyboard shortcuts, and full history. Better than email for interactive newsletter reading with embedded videos and blogs.
-  "og:title": Summate Web Reader - Interactive Digest Reading Experience
-  "og:description": Read digests online with embedded content, keyboard shortcuts, and access to full history. Better experience than email for newsletters, YouTube, and blogs.
+description: Access all your digests at summate.io/v2/issues with embedded content, keyboard shortcuts, and full history. Better than email for interactive newsletter reading with embedded videos and blogs.
+"og:title": Summate Web Reader - Interactive Digest Reading Experience
+"og:description": Read digests online with embedded content, keyboard shortcuts, and access to full history. Better experience than email for newsletters, YouTube, and blogs.
 keywords: ["web reader", "keyboard shortcuts", "online reading", "embedded content", "digest history"]
 ---
 


### PR DESCRIPTION
- Add global SEO configuration to mint.json (OG tags, indexing)
- Update all page frontmatter with SEO-optimized titles (50-60 chars)
- Add separate meta descriptions (150-160 chars) for search engines
- Keep short on-page descriptions for better UX
- Create comprehensive introduction.mdx landing page
- Add keywords for internal search on all pages
- Target long-tail keywords (gmail forwarding, substack import, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)