### PR TITLE
Review and Improve Documentation Structure

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -57,74 +57,26 @@ Instead of checking multiple inboxes, apps, and websites throughout the day, Sum
   </Card>
 </CardGroup>
 
-## What You Can Aggregate
+## Explore Key Concepts
 
-<Tabs>
-  <Tab title="Email Newsletters">
-    Forward newsletters from any platform (Substack, Beehiiv, ConvertKit, etc.) to your unique Summate inbox address.
-
-    **Features:**
-    - Automatic sender management
-    - One-click spam blocking
-    - Works with all email providers
-    - Keep your personal inbox private
-
-    [Learn about the Inbox →](/concepts/inbox)
-  </Tab>
-
-  <Tab title="YouTube Videos">
-    Import your YouTube subscriptions or add channels manually to get video summaries with timestamped takeaways.
-
-    **Features:**
-    - One-click subscription import
-    - Filter out Shorts
-    - Clickable timestamp links
-    - Skip to relevant moments
-
-    [Learn about YouTube blocks →](/concepts/blocks#youtube-block)
-  </Tab>
-
-  <Tab title="RSS Feeds & Blogs">
-    Add any blog or website with an RSS feed. Auto-detect feeds or paste URLs directly.
-
-    **Features:**
-    - Automatic feed detection
-    - Substack import
-    - Content filtering
-    - Paragraph-level references
-
-    [Learn about RSS blocks →](/concepts/blocks#rss-block)
-  </Tab>
-</Tabs>
-
-## Key Features
-
-### AI-Powered Summaries
-
-Every piece of content gets summarized with:
-- **TLDR** - Quick overview of the main points
-- **Key Takeaways** - Specific insights relevant to your custom instructions
-- **Interactive References** - Click takeaways to jump to exact paragraphs or video timestamps
-
-[Learn about AI Personalization →](/concepts/ai)
-
-### Flexible Scheduling
-
-Receive digests exactly when you need them:
-- **Daily** - Morning brief, afternoon updates (min. 4 hours apart)
-- **Weekly** - Specific days and times (e.g., Mon/Wed/Fri at 9 AM)
-- **Monthly** - Choose which days of the month
-
-[Learn about Digest Scheduling →](/concepts/digests#scheduling-your-digests)
-
-### Multiple Reading Options
-
-<CardGroup cols={2}>
-  <Card title="Email" icon="envelope" href="/reading/email">
-    Receive digests in your inbox. Read in any email client with interactive links to full content.
+<CardGroup cols={3}>
+  <Card title="Digests" icon="newspaper" href="/concepts/digests">
+    Scheduled AI summaries delivered on your timeline
   </Card>
-  <Card title="Web Reader" icon="globe" href="/reading/web">
-    Access all digests online with embedded content, keyboard shortcuts, and full history.
+  <Card title="Blocks" icon="cube" href="/concepts/blocks">
+    Organize newsletters, YouTube, and RSS sources
+  </Card>
+  <Card title="AI Personalization" icon="sparkles" href="/concepts/ai">
+    Customize summaries with custom instructions
+  </Card>
+  <Card title="Your Inbox" icon="inbox" href="/concepts/inbox">
+    Private email address for newsletter collection
+  </Card>
+  <Card title="Read Anywhere" icon="book-open" href="/reading/web">
+    Email delivery and web reader options
+  </Card>
+  <Card title="Sources" icon="rss" href="/concepts/sources">
+    Manage your content providers
   </Card>
 </CardGroup>
 
@@ -172,17 +124,6 @@ Receive digests exactly when you need them:
   </Accordion>
 </AccordionGroup>
 
-## Pricing
-
-**$10/month, billed yearly** during beta
-- 2000 AI credits per month (~66 items/day)
-- Unlimited digests
-- All content sources (Email, YouTube, RSS)
-- Email and web delivery
-- 14-day free trial
-
-[View Credit Pricing →](/account#ai-credits)
-
 ## Get Started in 5 Minutes
 
 <CardGroup cols={3}>
@@ -194,21 +135,6 @@ Receive digests exactly when you need them:
   </Card>
   <Card title="FAQ" icon="circle-question" href="/getting-started/faq">
     Common questions about pricing, features, and troubleshooting.
-  </Card>
-</CardGroup>
-
-## How Summate Compares
-
-<CardGroup cols={2}>
-  <Card title="vs. Reading Everything Manually">
-    **Without Summate:** 2-3 hours/day checking newsletters, YouTube, and blogs
-
-    **With Summate:** 15-30 minutes reading AI summaries with links to dive deeper
-  </Card>
-  <Card title="vs. Traditional RSS Readers">
-    **Traditional RSS:** No AI summaries, no email integration, separate app for YouTube
-
-    **Summate:** AI summaries, unified platform, email + YouTube + RSS in one digest
   </Card>
 </CardGroup>
 


### PR DESCRIPTION
Simplified introduction.mdx from 236 to 162 lines (31% reduction) by:

- Removed detailed feature explanations (moved to Concepts pages)
- Removed "What You Can Aggregate" tabs (replaced with concept links)
- Removed pricing section (users can find in FAQ/Account)
- Removed "How Summate Compares" section (better for blog)
- Removed "Multiple Reading Options" CardGroup (redundant)
- Added "Explore Key Concepts" CardGroup linking to existing concept pages

Result: Cleaner landing page that directs users to deep-dive pages rather than overwhelming them with details upfront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)